### PR TITLE
update mlir workflow

### DIFF
--- a/neovim10_2/after/plugin/lsp.lua
+++ b/neovim10_2/after/plugin/lsp.lua
@@ -28,7 +28,7 @@ vim.api.nvim_create_autocmd('LspAttach', {
     vim.keymap.set({'n', 'x'}, '<F3>', '<cmd>lua vim.lsp.buf.format({async = true})<cr>', opts)
     vim.keymap.set('n', '<leader>ca', '<cmd>lua vim.lsp.buf.code_action()<cr>', opts)
 
-    vim.keymap.set('n', '<leader>i', '<cmd>ClangdToggleInlayHints<cr>', opts)
+    vim.keymap.set('n', '<leader>i', 'lua vim.lsp.inlay_hint.enable(not vim.lsp.inlay_hint.is_enabled())<cr>', opts)
   end,
 })
 
@@ -88,8 +88,6 @@ require('vim.lsp.log').set_level(0)
 local lspconfig = require'lspconfig'
 
 lspconfig.clangd.setup{}
-require("clangd_extensions.inlay_hints").setup_autocmd()
-require("clangd_extensions.inlay_hints").set_inlay_hints()
 
 -- mlir stuff
 lspconfig.mlir_lsp_server.setup{
@@ -102,8 +100,8 @@ lspconfig.mlir_lsp_server.setup{
 lspconfig.tblgen_lsp_server.setup({
    on_new_config = function(config)
      config.cmd = {
-       "llvm-18.1.6-assert/bin/tblgen-lsp-server",
-       "--tablegen-compilation-database=build/tablegen_compile_commands.yml"
+       "/home/zilleplus/public_code/llvm-18.1.6-assert/bin/tblgen-lsp-server",
+       "--tablegen-compilation-database=/home/zilleplus/code/cpp/mlir-experiment/build/tablegen_compile_commands.yml"
      }
    end,
 })
@@ -111,7 +109,7 @@ lspconfig.mlir_pdll_lsp_server.setup{
    on_new_config = function(config)
      config.cmd = {
        "llvm-18.1.6-assert/bin/pdll-lsp-server",
-       "--tablegen-compilation-database=build/tablegen_compile_commands.yml"
+       "--tablegen-compilation-database=/home/zilleplus/code/cpp/mlir-experiment/build/tablegen_compile_commands.yml"
      }
    end,
 }

--- a/neovim10_2/after/plugin/telescope.lua
+++ b/neovim10_2/after/plugin/telescope.lua
@@ -1,7 +1,7 @@
 local builtin = require('telescope.builtin')
+local telescop_ext = require('telescope').extensions.live_grep_args
 vim.keymap.set('n', '<leader>ff', builtin.find_files, {})
 vim.keymap.set('n', '<leader>fg', builtin.live_grep, {})
+vim.keymap.set('n', '<leader>fm', telescop_ext.live_grep_args, {})
 vim.keymap.set('n', '<leader>fb', builtin.buffers, {})
 vim.keymap.set('n', '<leader>fh', builtin.help_tags, {})
-
-

--- a/neovim10_2/lazy-lock.json
+++ b/neovim10_2/lazy-lock.json
@@ -1,10 +1,11 @@
 {
-  "clangd_extensions.nvim": { "branch": "main", "commit": "8f7b72100883e0e34400d9518d40a03f21e4d0a6" },
-  "cmp-nvim-lsp": { "branch": "main", "commit": "39e2eda76828d88b773cc27a3f61d2ad782c922d" },
-  "lazy.nvim": { "branch": "main", "commit": "cf8ecc2c5e4332760431a33534240b0cbc6680ab" },
-  "nvim-cmp": { "branch": "main", "commit": "f17d9b4394027ff4442b298398dfcaab97e40c4f" },
-  "nvim-lspconfig": { "branch": "master", "commit": "bc6ada4b0892b7f10852c0b8ca7209fd39a6d754" },
-  "plenary.nvim": { "branch": "master", "commit": "2d9b06177a975543726ce5c73fca176cedbffe9d" },
-  "rose-pine": { "branch": "main", "commit": "07a887a7bef4aacea8c7caebaf8cbf808cdc7a8e" },
+  "clangd_extensions.nvim": { "branch": "main", "commit": "db28f29be928d18cbfb86fbfb9f83f584f658feb" },
+  "cmp-nvim-lsp": { "branch": "main", "commit": "99290b3ec1322070bcfb9e846450a46f6efa50f0" },
+  "lazy.nvim": { "branch": "main", "commit": "6c3bda4aca61a13a9c63f1c1d1b16b9d3be90d7a" },
+  "nvim-cmp": { "branch": "main", "commit": "c27370703e798666486e3064b64d59eaf4bdc6d5" },
+  "nvim-lspconfig": { "branch": "master", "commit": "8e8fd432f05b126a9dd1635e8022c7e7d1a04e60" },
+  "plenary.nvim": { "branch": "master", "commit": "857c5ac632080dba10aae49dba902ce3abf91b35" },
+  "rose-pine": { "branch": "main", "commit": "7718965bdd1526b233f082da17e88b8bde7a7e6e" },
+  "telescope-live-grep-args.nvim": { "branch": "master", "commit": "b80ec2c70ec4f32571478b501218c8979fab5201" },
   "telescope.nvim": { "branch": "master", "commit": "a0bbec21143c7bc5f8bb02e0005fa0b982edc026" }
 }

--- a/neovim10_2/lua/zilleplus/init.lua
+++ b/neovim10_2/lua/zilleplus/init.lua
@@ -22,8 +22,15 @@ require("lazy").setup({
     {'hrsh7th/cmp-nvim-lsp'},
     {'rose-pine/neovim', name = 'rose-pine' },
     {
-    'nvim-telescope/telescope.nvim', tag = '0.1.8',
-      dependencies = { 'nvim-lua/plenary.nvim' }
+      -- live-grep allows the user to add arguments to 
+      -- rg while searching
+      -- example: --glob=*.td tosa 
+      --    -> find all the td files with tosa in it
+      --    -> "!" negates the search
+      "nvim-telescope/telescope-live-grep-args.nvim",
+      dependencies = 
+      { 'nvim-lua/plenary.nvim', -- coroutines used by telescope
+        'nvim-telescope/telescope.nvim' }
     }
 })
 


### PR DESCRIPTION
* Update the plugins, clangd lsp extension removed hints as it's now an internal lsp feature. Adjusted the config to not use that clangd-extension feature anymore.
* Added a find to telescope that allows you to add arguments to the rg command. The main usecase is filtering out what dir should be included/excluded eg. --glob=*.td .